### PR TITLE
remove duplicated scm tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/evolvedbinary/PLMultiAnalyzer</developerConnection>
+        <connection>scm:git:https://github.com/evolvedbinary/PLMultiAnalyzer.git</connection>
+        <url>scm:git:https://github.com/evolvedbinary/PLMultiAnalyzer.git</url>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>
@@ -51,13 +54,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
-    <scm>
-        <connection>scm:git:https://github.com/evolvedbinary/PLMultiAnalyzer.git</connection>
-        <developerConnection>scm:git:https://github.com/evolvedbinary/PLMultiAnalyzer.git</developerConnection>
-        <url>scm:git:https://github.com/evolvedbinary/PLMultiAnalyzer.git</url>
-        <tag>HEAD</tag>
-    </scm>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -206,7 +202,7 @@
                         <Source-Repository>${project.scm.connection}</Source-Repository>
                         <Description>${project.description}</Description>
                         <Implementation-URL>${project.url}</Implementation-URL>
-                    </manifestEntries>  
+                    </manifestEntries>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
for some reason we had a duplicated scm tag 
maven doesn't install any dependencies with  that duplication 