### PR TITLE
new constructor with know types for easy integration with exist db

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ the `Analyzer` needs two parameters
                 <param name="punctuationDictionary" type="java.util.Set">
                     <value>'</value>
                     <value>-</value>
-                    <value>’</value> 
-                    <value>_</value>
+                    <value>’</value>
                 </param>
             </analyzer>
             <text qname="SAMPLE" analyzer="cus"/>

--- a/README.md
+++ b/README.md
@@ -76,15 +76,16 @@ the `Analyzer` needs two parameters
     <index xmlns:wiki="http://exist-db.org/xquery/wiki" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:atom="http://www.w3.org/2005/Atom">
         <!-- Lucene index is configured below -->
         <lucene>
-	        <analyzer class="com.evolvedbinary.lucene.analyzer.OhAnalyzer">
-                <param name="minimumTermLength" type="int" value="2" />
-                <param name="punctuationDictionary" type="org.apache.lucene.analysis.util.CharArraySet">
+	        <analyzer id="cus" class="com.evolvedbinary.lucene.analyzer.OhAnalyzer">
+                <param name="minimumTermLength" type="java.lang.Integer" value="2" />
+                <param name="punctuationDictionary" type="java.util.Set">
                     <value>'</value>
                     <value>-</value>
-                    <value>’</value>
+                    <value>’</value> 
+                    <value>_</value>
                 </param>
-            <analyzer>
-	        <text qname="doc"/>
+            </analyzer>
+            <text qname="SAMPLE" analyzer="cus"/>
         </lucene>
     </index>
 </collection>

--- a/src/main/java/com/evolvedbinary/lucene/analyzer/OhAnalyzer.java
+++ b/src/main/java/com/evolvedbinary/lucene/analyzer/OhAnalyzer.java
@@ -22,14 +22,16 @@
  */
 package com.evolvedbinary.lucene.analyzer;
 
-import it.unimi.dsi.fastutil.chars.CharArraySet;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.util.Version;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Set;
 
 public class OhAnalyzer extends Analyzer {
     private final char[] punctuationDictionary;
@@ -54,13 +56,22 @@ public class OhAnalyzer extends Analyzer {
      * @param minimumTermLength the minimum length of any decomposed term,
      *     any smaller decomposed terms will be discarded. Set to 0 to
      *     indicate no minimum.
-     *
-     * @deprecated Use {@link #OhAnalyzer(char[], int)} instead
      */
-    @Deprecated
-    public OhAnalyzer(final CharArraySet punctuationDictionary, final int minimumTermLength) {
-        this(punctuationDictionary.toCharArray(), minimumTermLength);
+    public OhAnalyzer(final Integer minimumTermLength, final Set<Character> punctuationDictionary) {
+        super();
+        this.punctuationDictionary =punctuationDictionary.toString().toCharArray();
+        this.minimumTermLength = minimumTermLength;
     }
+    /**
+     * when no params are provided the default ones will be used 
+     */
+    public OhAnalyzer() {
+        super();
+        this.punctuationDictionary = new char[]{'\'', '-', '\u2019'};;
+        this.minimumTermLength = 2;
+    }
+
+
 
     @Override
     protected TokenStreamComponents createComponents(final String fieldName, final Reader reader) {


### PR DESCRIPTION
as i was trying to use the analyzer with exist db the constructor signature was not being picked up by exist 
the issue was the types we used in the constructor params `int` and  `char[]`
i switched to using `java.lang.Integer` and `java.util.Set`
now the current config looks like
```xml
<analyzer id="cus" class="com.evolvedbinary.lucene.analyzer.OhAnalyzer">
            <param name="minimumTermLength" type="java.lang.Integer" value="2" />
            <param name="punctuationDictionary" type="java.util.Set">
                <value>'</value>
                <value>-</value>
                <value>’</value> 
            </param>
</analyzer>
```