### PR TITLE
lowercase terms with parentheses

### DIFF
--- a/src/main/java/com/evolvedbinary/lucene/analyzer/OhFilter.java
+++ b/src/main/java/com/evolvedbinary/lucene/analyzer/OhFilter.java
@@ -97,8 +97,8 @@ public final class OhFilter extends TokenFilter {
         // create extra terms by decomposing the term on word boundaries
         decomposePunctuationWordBoundaries(term);
 
-        // if the term starts with an upper-case character, produce a lower-case term
-        if (Character.isUpperCase(term.charAt(0))) {
+        // decide whether we lowercase the term or not
+        if (shouldLowerCaseTerm(term)) {
             final String lowerCaseTerm = term.toLowerCase();
 
             // add the lower-case term as an extra term
@@ -160,5 +160,15 @@ public final class OhFilter extends TokenFilter {
                 }
             }
         }
+    }
+
+    private boolean shouldLowerCaseTerm(final String term) {
+        // if the term starts with an upper-case character
+        if (Character.isUpperCase(term.charAt(0))) return true;
+
+        // if the term starts with an upper-case character after parentheses
+        if(term.charAt(0) == '(' && Character.isUpperCase(term.charAt(1))) return true;
+
+        return false;
     }
 }

--- a/src/main/java/com/evolvedbinary/lucene/analyzer/OhFilter.java
+++ b/src/main/java/com/evolvedbinary/lucene/analyzer/OhFilter.java
@@ -97,9 +97,10 @@ public final class OhFilter extends TokenFilter {
         // create extra terms by decomposing the term on word boundaries
         decomposePunctuationWordBoundaries(term);
 
+        final String lowerCaseTerm = term.toLowerCase();
+
         // decide whether we lowercase the term or not
-        if (shouldLowerCaseTerm(term)) {
-            final String lowerCaseTerm = term.toLowerCase();
+        if (!term.equals(lowerCaseTerm)) {
 
             // add the lower-case term as an extra term
             extraTerms.add(lowerCaseTerm);
@@ -160,15 +161,5 @@ public final class OhFilter extends TokenFilter {
                 }
             }
         }
-    }
-
-    private boolean shouldLowerCaseTerm(final String term) {
-        // if the term starts with an upper-case character
-        if (Character.isUpperCase(term.charAt(0))) return true;
-
-        // if the term starts with an upper-case character after parentheses
-        if(term.charAt(0) == '(' && Character.isUpperCase(term.charAt(1))) return true;
-
-        return false;
     }
 }

--- a/src/test/java/com/evolvedbinary/lucene/analyzer/OhAnalyzerTest.java
+++ b/src/test/java/com/evolvedbinary/lucene/analyzer/OhAnalyzerTest.java
@@ -239,7 +239,7 @@ public class OhAnalyzerTest {
         }
         System.out.println();
 
-        assertArrayEquals(new String[] { "(TS)"}, tokens.toArray(new String[0]));
+        assertArrayEquals(new String[] { "(TS)", "(ts)"}, tokens.toArray(new String[0]));
     }
 
     @Test


### PR DESCRIPTION
this adds a function to decided when to lowerCase the term 
the current rules we implement are:
* term start with UpperCase eg: Word

the new suggested rule:
* term start with `(` parentheses followed by UpperCase eg: (Test

needs discussion:
* term with UpperCase no matter the position 

as the analyzer shows the results based on the tokens we produce we can be excluding results from showing up 
example:
`dreamWorks` will produce [dreamWorks] as the  sole token that returns this results
if we search for `dearmworks` we will not get results from the latter 

@adamretter  what do you think?